### PR TITLE
docs: API -> Interface

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Authors@R: c(
     person("Posit Software, PBC", role = c("cph", "fnd"))
   )
 Description: Defines a set of generics that provide a low-level
-    implementer's interface for dplyr's high-level API.
+    implementer's interface for dplyr's high-level interface.
 License: MIT + file LICENSE
 URL: https://github.com/krlmlr/duckplyr, https://krlmlr.github.io/duckplyr/
 BugReports: https://github.com/krlmlr/duckplyr/issues


### PR DESCRIPTION
Not sure about this one but as you noted elsewhere, "API" might be flagged as an unexplained acronym.